### PR TITLE
Fix crawling loop when maxPages omitted

### DIFF
--- a/src/services/ScraperService.ts
+++ b/src/services/ScraperService.ts
@@ -108,7 +108,11 @@ export class ScraperService {
     let queue: string[] = [startUrl];
     let pageCount = 0;
     
-    while (queue.length > 0 && this.isCrawling && (options.maxPages && pageCount < options.maxPages)) {
+    while (
+      queue.length > 0 &&
+      this.isCrawling &&
+      (options.maxPages === undefined || pageCount < options.maxPages)
+    ) {
       const url = queue.shift()!;
       
       if (visited.has(url)) continue;


### PR DESCRIPTION
## Summary
- handle undefined maxPages when crawling websites

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841bea1a8d8832194fa272c39df94fc