### PR TITLE
Add Supabase team tables and RLS

### DIFF
--- a/src/components/SaveProjectButton.tsx
+++ b/src/components/SaveProjectButton.tsx
@@ -33,7 +33,7 @@ export function SaveProjectButton({
   const [processingEmbeddings, setProcessingEmbeddings] = useState(false);
   const [withEmbeddings, setWithEmbeddings] = useState(false);
   const { toast } = useToast();
-  const { user } = useAuth();
+  const { user, currentTeamId } = useAuth();
 
   const handleSave = async () => {
     if (!user) {
@@ -48,7 +48,7 @@ export function SaveProjectButton({
     setSaving(true);
     try {
       // Save the project first
-      const savedProject = await ContentService.saveProject(title, startUrl, contents);
+      const savedProject = await ContentService.saveProject(title, startUrl, contents, currentTeamId || null);
       
       if (!savedProject) {
         throw new Error("Failed to save project");

--- a/src/components/ScrapeForm.tsx
+++ b/src/components/ScrapeForm.tsx
@@ -10,6 +10,7 @@ import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { ProjectService } from "@/services/ProjectService";
 import { ContentService } from "@/services/ContentService";
+import { useAuth } from "@/context/AuthContext";
 
 interface ScrapeFormProps {
   onResult: (data: ScrapedContent) => void;
@@ -25,6 +26,7 @@ export function ScrapeForm({ onResult, onCrawlComplete, projectId, inProjectView
   const [maxPages, setMaxPages] = useState(10);
   const [projectName, setProjectName] = useState("");
   const [generateEmbeddings, setGenerateEmbeddings] = useState(true);
+  const { currentTeamId } = useAuth();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -72,9 +74,10 @@ export function ScrapeForm({ onResult, onCrawlComplete, projectId, inProjectView
               if (projectDetails) {
                 // Save all the crawled content to the database
                 await ContentService.saveProject(
-                  projectDetails.title, 
-                  processedUrl, 
-                  allResults
+                  projectDetails.title,
+                  processedUrl,
+                  allResults,
+                  currentTeamId || null
                 );
                 
                 toast({

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -14,11 +14,18 @@ import { User, LogOut, Settings, Shield, Info } from "lucide-react";
 import { RoleService } from "@/services/RoleService";
 
 export function UserMenu() {
-  const { user, signOut } = useAuth();
+  const { user, signOut, teams, currentTeamId, joinTeam, switchTeam } = useAuth();
   const { isMasterAdmin } = useRole();
 
   const handleGetUserId = async () => {
     await RoleService.printCurrentUserId();
+  };
+
+  const handleJoinTeam = async () => {
+    const teamId = window.prompt('Enter Team ID');
+    if (teamId) {
+      await joinTeam(teamId);
+    }
   };
 
   if (!user) {
@@ -52,6 +59,24 @@ export function UserMenu() {
             <Settings className="mr-2 h-4 w-4" />
             <span>Dashboard</span>
           </Link>
+        </DropdownMenuItem>
+        {teams.length > 0 && (
+          <div className="px-2 py-1">
+            <p className="text-xs mb-1">Teams</p>
+            {teams.map((team) => (
+              <DropdownMenuItem
+                key={team.id}
+                onClick={() => switchTeam(team.id)}
+                className="cursor-pointer"
+              >
+                {team.name}
+                {team.id === currentTeamId && ' ✓'}
+              </DropdownMenuItem>
+            ))}
+          </div>
+        )}
+        <DropdownMenuItem onClick={handleJoinTeam} className="cursor-pointer">
+          Join Team
         </DropdownMenuItem>
         {/* TEMPORARY: Remove after setup */}
         <DropdownMenuItem onClick={handleGetUserId} className="flex items-center cursor-pointer text-blue-600">

--- a/src/components/chat/ChatDemo.tsx
+++ b/src/components/chat/ChatDemo.tsx
@@ -11,15 +11,15 @@ import { useEffect } from "react";
 
 const ChatDemo = () => {
   const { id } = useParams<{ id: string }>();
-  const { user } = useAuth();
-  const { 
-    projects, 
-    selectedProject, 
+  const { user, currentTeamId } = useAuth();
+  const {
+    projects,
+    selectedProject,
     selectedConversationId,
     handleProjectSelect,
     handleConversationSelect,
     handleConversationCreated
-  } = useProjectSelection(id);
+  } = useProjectSelection(id, currentTeamId);
   
   // Move the authentication check after all hooks are initialized
   if (!user) {

--- a/src/hooks/use-project-selection.ts
+++ b/src/hooks/use-project-selection.ts
@@ -4,7 +4,7 @@ import { SavedProject, ContentService } from "@/services/ContentService";
 import { ChatConversation, ChatService } from "@/services/ChatService";
 import { useNavigate } from "react-router-dom";
 
-export function useProjectSelection(projectId?: string) {
+export function useProjectSelection(projectId?: string, teamId?: string | null) {
   const [projects, setProjects] = useState<SavedProject[]>([]);
   const [selectedProject, setSelectedProject] = useState<SavedProject | null>(null);
   const [selectedConversationId, setSelectedConversationId] = useState<string | undefined>(undefined);
@@ -15,7 +15,7 @@ export function useProjectSelection(projectId?: string) {
   useEffect(() => {
     const fetchProjects = async () => {
       try {
-        const userProjects = await ContentService.getUserProjects();
+        const userProjects = await ContentService.getUserProjects(teamId || null);
         setProjects(userProjects);
         
         // If we have a project ID in the URL, select that project
@@ -34,7 +34,7 @@ export function useProjectSelection(projectId?: string) {
     };
     
     fetchProjects();
-  }, [projectId]);
+  }, [projectId, teamId]);
   
   // Fetch conversations when project changes
   useEffect(() => {

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -433,6 +433,7 @@ export type Database = {
           title: string
           url: string
           user_id: string
+          team_id: string | null
         }
         Insert: {
           created_at?: string
@@ -441,6 +442,7 @@ export type Database = {
           title: string
           url: string
           user_id: string
+          team_id?: string | null
         }
         Update: {
           created_at?: string
@@ -449,6 +451,49 @@ export type Database = {
           title?: string
           url?: string
           user_id?: string
+          team_id?: string | null
+        }
+        Relationships: []
+      }
+      teams: {
+        Row: {
+          id: string
+          name: string
+          created_at: string | null
+          updated_at: string | null
+        }
+        Insert: {
+          id?: string
+          name: string
+          created_at?: string | null
+          updated_at?: string | null
+        }
+        Update: {
+          id?: string
+          name?: string
+          created_at?: string | null
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
+      team_memberships: {
+        Row: {
+          id: string
+          team_id: string | null
+          user_id: string | null
+          created_at: string | null
+        }
+        Insert: {
+          id?: string
+          team_id?: string | null
+          user_id?: string | null
+          created_at?: string | null
+        }
+        Update: {
+          id?: string
+          team_id?: string | null
+          user_id?: string | null
+          created_at?: string | null
         }
         Relationships: []
       }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -23,7 +23,7 @@ const Dashboard = () => {
   const [savedProjects, setSavedProjects] = useState<SavedProject[]>([]);
   const [loadingSaved, setLoadingSaved] = useState(false);
   const [activeTab, setActiveTab] = useState<string>("create");
-  const { user } = useAuth();
+  const { user, currentTeamId } = useAuth();
 
   // Redirect if not logged in
   if (!user) {
@@ -37,7 +37,7 @@ const Dashboard = () => {
     const fetchSavedProjects = async () => {
       setLoadingSaved(true);
       try {
-        const projects = await ContentService.getUserProjects();
+        const projects = await ContentService.getUserProjects(currentTeamId);
         setSavedProjects(projects);
       } catch (error) {
         console.error("Error fetching saved projects:", error);
@@ -47,7 +47,7 @@ const Dashboard = () => {
     };
     
     fetchSavedProjects();
-  }, [user]);
+  }, [user, currentTeamId]);
 
   const handleResult = (data: ScrapedContent) => {
     setScrapedData(data);

--- a/src/pages/ProjectWizard.tsx
+++ b/src/pages/ProjectWizard.tsx
@@ -61,7 +61,7 @@ export interface ProjectSettings {
 }
 
 const ProjectWizard = () => {
-  const { user } = useAuth();
+  const { user, currentTeamId } = useAuth();
   const navigate = useNavigate();
   
   // State for the active wizard step
@@ -194,7 +194,8 @@ const ProjectWizard = () => {
       const savedProject = await ContentService.saveProject(
         projectSettings.basicInfo.name,
         projectSettings.basicInfo.url,
-        emptyContent
+        emptyContent,
+        currentTeamId || null
       );
       
       if (!savedProject) {

--- a/src/services/RescanService.ts
+++ b/src/services/RescanService.ts
@@ -110,7 +110,7 @@ export class RescanService {
         
         if (contentToUpdate.length > 0) {
           // Save to database
-          await ContentService.saveProject(project.title, project.url, contentToUpdate);
+          await ContentService.saveProject(project.title, project.url, contentToUpdate, project.team_id || null);
         }
       }
       

--- a/src/services/TeamService.ts
+++ b/src/services/TeamService.ts
@@ -1,0 +1,39 @@
+import { supabase } from "@/integrations/supabase/client";
+import { Database } from "@/integrations/supabase/types";
+
+export interface Team {
+  id: string;
+  name: string;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+export const TeamService = {
+  async getUserTeams(): Promise<Team[]> {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return [];
+    const { data, error } = await supabase
+      .from('team_memberships')
+      .select('teams(*)')
+      .eq('user_id', user.id);
+    if (error) {
+      console.error('Error fetching teams', error);
+      return [];
+    }
+    return (data || []).map((tm) => tm.teams) as Team[];
+  },
+
+  async joinTeam(teamId: string): Promise<boolean> {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return false;
+    const { error } = await supabase
+      .from('team_memberships')
+      .insert({ team_id: teamId, user_id: user.id } as Database['public']['Tables']['team_memberships']['Insert']);
+    if (error) {
+      console.error('Error joining team', error);
+      return false;
+    }
+    return true;
+  }
+};
+

--- a/supabase/migrations/20250522_create_team_tables.sql
+++ b/supabase/migrations/20250522_create_team_tables.sql
@@ -1,0 +1,21 @@
+-- Create teams table
+create table if not exists teams (
+  id uuid primary key default uuid_generate_v4(),
+  name text not null,
+  created_at timestamp with time zone default now(),
+  updated_at timestamp with time zone default now()
+);
+
+-- Create team_memberships table
+create table if not exists team_memberships (
+  id uuid primary key default uuid_generate_v4(),
+  team_id uuid references teams(id) on delete cascade,
+  user_id uuid references auth.users(id) on delete cascade,
+  created_at timestamp with time zone default now(),
+  unique(team_id, user_id)
+);
+
+-- Add team_id column to scraped_projects
+alter table if exists scraped_projects
+  add column if not exists team_id uuid references teams(id) on delete set null;
+

--- a/supabase/migrations/20250523_rls_teams_projects.sql
+++ b/supabase/migrations/20250523_rls_teams_projects.sql
@@ -1,0 +1,41 @@
+-- Enable RLS on team-related tables
+alter table teams enable row level security;
+alter table team_memberships enable row level security;
+alter table scraped_projects enable row level security;
+
+-- Teams policies: only members can select/update/delete
+create policy "select team" on teams for select using (
+  exists(select 1 from team_memberships m where m.team_id = id and m.user_id = auth.uid())
+);
+create policy "insert team" on teams for insert with check (auth.uid() = auth.uid());
+create policy "update team" on teams for update using (
+  exists(select 1 from team_memberships m where m.team_id = id and m.user_id = auth.uid())
+);
+create policy "delete team" on teams for delete using (
+  exists(select 1 from team_memberships m where m.team_id = id and m.user_id = auth.uid())
+);
+
+-- Team memberships policies
+create policy "select membership" on team_memberships for select using (
+  user_id = auth.uid()
+);
+create policy "insert membership" on team_memberships for insert with check (
+  user_id = auth.uid()
+);
+create policy "delete membership" on team_memberships for delete using (
+  user_id = auth.uid()
+);
+
+-- Project policies
+create policy "select project by team" on scraped_projects for select using (
+  exists(select 1 from team_memberships m where m.team_id = team_id and m.user_id = auth.uid())
+);
+create policy "insert project by team" on scraped_projects for insert with check (
+  exists(select 1 from team_memberships m where m.team_id = team_id and m.user_id = auth.uid())
+);
+create policy "update project by team" on scraped_projects for update using (
+  exists(select 1 from team_memberships m where m.team_id = team_id and m.user_id = auth.uid())
+);
+create policy "delete project by team" on scraped_projects for delete using (
+  exists(select 1 from team_memberships m where m.team_id = team_id and m.user_id = auth.uid())
+);


### PR DESCRIPTION
## Summary
- add migrations for `teams` and `team_memberships`
- lock down `scraped_projects` via RLS
- update Supabase type definitions
- add TeamService and extend AuthContext with team support
- include team ID when saving or fetching projects
- expose join/switch team UI in UserMenu

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script)*
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68423bd708fc8321a2952515c1f79b83