### PR TITLE
Add embedding job queue and progress tracking

### DIFF
--- a/src/components/chat/ChatContainer.tsx
+++ b/src/components/chat/ChatContainer.tsx
@@ -19,6 +19,7 @@ export function ChatContainer({ project }: ChatContainerProps) {
     processingEmbeddings,
     hasEmbeddings,
     embeddingStatus,
+    progress,
     handleGenerateEmbeddings
   } = useEmbeddings(project.id);
   
@@ -40,6 +41,7 @@ export function ChatContainer({ project }: ChatContainerProps) {
           hasEmbeddings={hasEmbeddings}
           embeddingStatus={embeddingStatus}
           processingEmbeddings={processingEmbeddings}
+          progress={progress}
           onGenerateEmbeddings={handleGenerateEmbeddings}
         />
       </div>

--- a/src/components/chat/ChatStatusAlert.tsx
+++ b/src/components/chat/ChatStatusAlert.tsx
@@ -3,11 +3,13 @@ import React from "react";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { AlertCircle, CheckCircle, Info, Loader2 } from "lucide-react";
+import { Progress } from "@/components/ui/progress";
 
 interface ChatStatusAlertProps {
   hasEmbeddings: boolean;
   embeddingStatus: 'none' | 'processing' | 'success' | 'partial' | 'no-content';
   processingEmbeddings: boolean;
+  progress: number;
   onGenerateEmbeddings: () => void;
 }
 
@@ -15,6 +17,7 @@ export function ChatStatusAlert({
   hasEmbeddings,
   embeddingStatus,
   processingEmbeddings,
+  progress,
   onGenerateEmbeddings
 }: ChatStatusAlertProps) {
   if (hasEmbeddings) return null;
@@ -23,9 +26,10 @@ export function ChatStatusAlert({
     return (
       <Alert className="mb-4">
         <Loader2 className="h-4 w-4 animate-spin mr-2" />
-        <AlertTitle>Processing content</AlertTitle>
-        <AlertDescription>
-          We're processing your content to make it available for AI chat. This may take a few moments.
+        <AlertTitle>Processing content ({progress}%)</AlertTitle>
+        <AlertDescription className="space-y-2">
+          <p>We're processing your content to make it available for AI chat.</p>
+          <Progress value={progress} />
         </AlertDescription>
       </Alert>
     );

--- a/src/hooks/use-embedding-progress.ts
+++ b/src/hooks/use-embedding-progress.ts
@@ -1,0 +1,29 @@
+import { useQuery } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+
+export function useEmbeddingProgress(projectId: string, enabled: boolean) {
+  return useQuery({
+    queryKey: ["embedding-progress", projectId],
+    queryFn: async () => {
+      const { count: total } = await supabase
+        .from('embedding_jobs')
+        .select('*', { count: 'exact', head: true })
+        .contains('payload', { projectId });
+
+      const { count: done } = await supabase
+        .from('embedding_jobs')
+        .select('*', { count: 'exact', head: true })
+        .contains('payload', { projectId })
+        .in('status', ['complete', 'failed']);
+
+      const { count: failed } = await supabase
+        .from('embedding_jobs')
+        .select('*', { count: 'exact', head: true })
+        .contains('payload', { projectId })
+        .eq('status', 'failed');
+
+      return { total: total || 0, done: done || 0, failed: failed || 0 };
+    },
+    refetchInterval: enabled ? 2000 : false,
+  });
+}

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -250,6 +250,30 @@ export type Database = {
           },
         ]
       }
+      embedding_jobs: {
+        Row: {
+          id: string
+          status: string
+          payload: Json
+          attempts: number
+          created_at: string | null
+        }
+        Insert: {
+          id?: string
+          status?: string
+          payload: Json
+          attempts?: number
+          created_at?: string | null
+        }
+        Update: {
+          id?: string
+          status?: string
+          payload?: Json
+          attempts?: number
+          created_at?: string | null
+        }
+        Relationships: []
+      }
       global_knowledge: {
         Row: {
           complexity_level: string | null

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -74,3 +74,6 @@ verify_jwt = false
 
 [functions.summarize-conversation]
 verify_jwt = false
+
+[functions.embedding-worker]
+verify_jwt = false

--- a/supabase/functions/embedding-worker/index.ts
+++ b/supabase/functions/embedding-worker/index.ts
@@ -1,0 +1,51 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.38.4";
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL') || '';
+  const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') || '';
+  const supabase = createClient(supabaseUrl, supabaseKey);
+
+  const { data: jobs, error } = await supabase
+    .from('embedding_jobs')
+    .select('*')
+    .eq('status', 'pending')
+    .order('created_at', { ascending: true })
+    .limit(5);
+
+  if (error) {
+    console.error('Error fetching jobs:', error);
+    return new Response(JSON.stringify({ error: 'failed to fetch jobs' }), { headers: corsHeaders, status: 500 });
+  }
+
+  let processed = 0;
+  for (const job of jobs ?? []) {
+    const { id, payload, attempts } = job as any;
+
+    await supabase.from('embedding_jobs').update({ status: 'processing', attempts: (attempts || 0) + 1 }).eq('id', id);
+
+    const { text, projectId, metadata } = payload || {};
+    const { data: result, error: procError } = await supabase.functions.invoke('process-embeddings', {
+      body: { text, projectId, metadata }
+    });
+
+    if (procError || result?.success !== true) {
+      await supabase.from('embedding_jobs').update({ status: 'failed' }).eq('id', id);
+    } else {
+      await supabase.from('embedding_jobs').update({ status: 'complete' }).eq('id', id);
+    }
+
+    processed++;
+  }
+
+  return new Response(JSON.stringify({ processed }), { headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+});

--- a/supabase/migrations/20250522_create_embedding_jobs_table.sql
+++ b/supabase/migrations/20250522_create_embedding_jobs_table.sql
@@ -1,0 +1,8 @@
+-- Create table to store embedding jobs for background processing
+CREATE TABLE IF NOT EXISTS embedding_jobs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  status text NOT NULL DEFAULT 'pending',
+  payload jsonb NOT NULL,
+  attempts integer NOT NULL DEFAULT 0,
+  created_at timestamp with time zone DEFAULT now()
+);


### PR DESCRIPTION
## Summary
- create `embedding_jobs` table migration
- add Supabase types for new table
- implement `embedding-worker` edge function
- queue embedding jobs in `EmbeddingService`
- track embedding progress with React Query
- display progress in chat UI
- allow embedding worker function in config

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68423bd7cfe48321b0618d3e94de909a