### PR TITLE
Implement global knowledge categories

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import BrandingDetails from "./pages/BrandingDetails";
 import AdminKnowledge from "./pages/AdminKnowledge";
 import { ChatDemo } from "./components/chat/ChatDemo";
 import ProjectWizard from "./pages/ProjectWizard";
+import WorkspaceSettings from "./pages/WorkspaceSettings";
 
 // Update document title
 document.title = "Beggor - Extract Website Content Like a Pro";
@@ -40,6 +41,7 @@ const App = () => (
               <Route path="/chat" element={<ChatDemo />} />
               <Route path="/chat/:id" element={<ChatDemo />} />
               <Route path="/admin/knowledge" element={<AdminKnowledge />} />
+              <Route path="/settings/:id" element={<WorkspaceSettings />} />
               {/* Redirect /dashboard to /chat */}
               <Route path="/dashboard" element={<Navigate to="/chat" replace />} />
               <Route path="*" element={<NotFound />} />

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -513,6 +513,7 @@ export type Database = {
           include_global?: boolean
           marketing_domain?: string
           complexity_level?: string
+          p_categories?: string[]
         }
         Returns: {
           id: string
@@ -534,6 +535,7 @@ export type Database = {
           p_marketing_domain?: string
           p_complexity_level?: string
           p_min_quality_score?: number
+          p_categories?: string[]
         }
         Returns: {
           id: string

--- a/src/pages/ProjectWizard.tsx
+++ b/src/pages/ProjectWizard.tsx
@@ -58,6 +58,7 @@ export interface ProjectSettings {
       property: string;
     };
   };
+  allowedCategories: string[];
 }
 
 const ProjectWizard = () => {
@@ -106,6 +107,7 @@ const ProjectWizard = () => {
         property: "",
       },
     },
+    allowedCategories: [],
   });
   
   // Check if basic information is valid

--- a/src/pages/WorkspaceSettings.tsx
+++ b/src/pages/WorkspaceSettings.tsx
@@ -1,0 +1,95 @@
+import { useState, useEffect } from 'react';
+import { useParams, Navigate } from 'react-router-dom';
+import { useAuth } from '@/context/AuthContext';
+import { Header } from '@/components/Header';
+import { GlobalKnowledgeService } from '@/services/GlobalKnowledgeService';
+import { ProjectSettingsService } from '@/services/ProjectSettingsService';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { toast } from '@/hooks/use-toast';
+
+interface Category {
+  id: string;
+  name: string;
+}
+
+const WorkspaceSettings = () => {
+  const { id } = useParams<{ id: string }>();
+  const { user } = useAuth();
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [selected, setSelected] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!user || !id) return;
+    const load = async () => {
+      setLoading(true);
+      const cats = await GlobalKnowledgeService.getCategories();
+      setCategories(cats);
+      const settings = await ProjectSettingsService.getProjectSettings(id);
+      setSelected(settings?.allowed_categories || []);
+      setLoading(false);
+    };
+    load();
+  }, [user, id]);
+
+  const toggle = (catId: string) => {
+    setSelected(prev =>
+      prev.includes(catId) ? prev.filter(c => c !== catId) : [...prev, catId]
+    );
+  };
+
+  const save = async () => {
+    if (!id) return;
+    setSaving(true);
+    const updated = await ProjectSettingsService.updateProjectSettings(id, {
+      allowedCategories: selected,
+    });
+    if (updated) {
+      toast({ title: 'Settings Saved', description: 'Workspace categories updated.' });
+    } else {
+      toast({ title: 'Error', description: 'Failed to save settings.', variant: 'destructive' });
+    }
+    setSaving(false);
+  };
+
+  if (!user) return <Navigate to="/auth" replace />;
+
+  return (
+    <div className="min-h-screen flex flex-col bg-white">
+      <Header />
+      <main className="flex-1 container max-w-4xl px-6 py-8">
+        <h1 className="text-2xl font-bold mb-4">Workspace Settings</h1>
+        <Card>
+          <CardHeader>
+            <CardTitle>Global Knowledge Categories</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {loading ? (
+              <p>Loading...</p>
+            ) : (
+              categories.map(cat => (
+                <label key={cat.id} className="flex items-center gap-2">
+                  <Checkbox
+                    checked={selected.includes(cat.id)}
+                    onCheckedChange={() => toggle(cat.id)}
+                  />
+                  <span>{cat.name}</span>
+                </label>
+              ))
+            )}
+          </CardContent>
+        </Card>
+        <div className="mt-4">
+          <Button onClick={save} disabled={saving}>
+            {saving ? 'Saving...' : 'Save'}
+          </Button>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default WorkspaceSettings;

--- a/src/services/GlobalKnowledgeService.ts
+++ b/src/services/GlobalKnowledgeService.ts
@@ -223,6 +223,28 @@ export class GlobalKnowledgeService {
   }
 
   /**
+   * Get list of global knowledge categories
+   */
+  public static async getCategories(): Promise<{ id: string; name: string }[]> {
+    try {
+      const { data, error } = await supabase
+        .from('global_categories')
+        .select('*')
+        .order('name');
+
+      if (error) {
+        console.error('Error fetching categories:', error);
+        return [];
+      }
+
+      return data || [];
+    } catch (error) {
+      console.error('Exception in getCategories:', error);
+      return [];
+    }
+  }
+
+  /**
    * Search global knowledge by content type and domain
    */
   public static async searchKnowledge(

--- a/src/services/MultiAgentService.ts
+++ b/src/services/MultiAgentService.ts
@@ -2,6 +2,7 @@
 import { OrchestratorAgent, OrchestratedResponse } from './agents/OrchestratorAgent';
 import { AgentContext } from './agents/BaseAgent';
 import { MemoryService } from './MemoryService';
+import { ProjectSettingsService } from './ProjectSettingsService';
 
 export class MultiAgentService {
   private static orchestrator = new OrchestratorAgent();
@@ -31,6 +32,10 @@ export class MultiAgentService {
       console.log(`Processing query with enhanced multi-agent system: "${message}"`);
       console.log(`Project ID: ${projectId}, Task Type: ${taskType}`);
 
+      // Load project settings to determine allowed categories
+      const projectSettings = await ProjectSettingsService.getProjectSettings(projectId);
+      const allowedCategories = projectSettings?.allowed_categories || [];
+
       // Get memory context for authenticated users with fallback
       let memoryContext = '';
       if (userContext?.isAuthenticated) {
@@ -55,6 +60,7 @@ export class MultiAgentService {
         query: message,
         projectId,
         taskType,
+        allowedCategories,
         userContext: {
           ...userContext,
           memoryContext

--- a/src/services/ProjectSettingsService.ts
+++ b/src/services/ProjectSettingsService.ts
@@ -8,6 +8,7 @@ export interface SavedProjectSettings {
   scraping_config: any;
   seo_settings: any;
   integrations: any;
+  allowed_categories: string[] | null;
   created_at: string;
   updated_at: string;
 }
@@ -22,7 +23,8 @@ export const ProjectSettingsService = {
           id: projectId,
           scraping_config: settings.scrapingConfig,
           seo_settings: settings.seoSettings,
-          integrations: settings.integrations
+          integrations: settings.integrations,
+          allowed_categories: settings.allowedCategories || []
         })
         .select()
         .single();
@@ -88,6 +90,10 @@ export const ProjectSettingsService = {
       
       if (settings.integrations) {
         updateData.integrations = settings.integrations;
+      }
+
+      if (settings.allowedCategories) {
+        updateData.allowed_categories = settings.allowedCategories;
       }
       
       if (Object.keys(updateData).length === 0) {

--- a/src/services/agents/BaseAgent.ts
+++ b/src/services/agents/BaseAgent.ts
@@ -3,6 +3,7 @@ export interface AgentContext {
   query: string;
   projectId: string;
   taskType: string;
+  allowedCategories?: string[];
   userContext?: any;
   previousAgentResults?: Record<string, any>;
 }

--- a/src/services/agents/ThinkingAgent.ts
+++ b/src/services/agents/ThinkingAgent.ts
@@ -29,7 +29,11 @@ export class ThinkingAgent extends BaseAgent {
 
     try {
       // First, get knowledge context from RAG
-      const ragContext = await this.getRAGContext(context.query, context.projectId);
+      const ragContext = await this.getRAGContext(
+        context.query,
+        context.projectId,
+        context.allowedCategories
+      );
       reasoning.push(`Retrieved ${ragContext.sources.length} relevant knowledge sources`);
 
       // Start thinking session
@@ -67,7 +71,11 @@ export class ThinkingAgent extends BaseAgent {
     }
   }
 
-  private async getRAGContext(query: string, projectId: string): Promise<{
+  private async getRAGContext(
+    query: string,
+    projectId: string,
+    categories?: string[]
+  ): Promise<{
     sources: any[];
     optimizedContext: string;
   }> {
@@ -88,7 +96,8 @@ export class ThinkingAgent extends BaseAgent {
         match_count: 10,
         p_project_id: projectId,
         include_global: true,
-        p_min_quality_score: 60
+        p_min_quality_score: 60,
+        p_categories: categories && categories.length > 0 ? categories : null
       });
 
       if (searchError || !sources) {

--- a/supabase/migrations/20250522_create_global_categories.sql
+++ b/supabase/migrations/20250522_create_global_categories.sql
@@ -1,0 +1,17 @@
+-- Create global_categories table
+CREATE TABLE IF NOT EXISTS global_categories (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL UNIQUE
+);
+
+-- Add category_id column to global_knowledge if not exists
+ALTER TABLE global_knowledge
+  ADD COLUMN IF NOT EXISTS category_id UUID REFERENCES global_categories(id);
+
+-- Tag existing documents with default 'general' category
+INSERT INTO global_categories (name)
+  VALUES ('general')
+  ON CONFLICT (name) DO NOTHING;
+UPDATE global_knowledge
+  SET category_id = (SELECT id FROM global_categories WHERE name = 'general')
+  WHERE category_id IS NULL;


### PR DESCRIPTION
## Summary
- add migration for global_categories and tag existing entries
- enable retrieving categories from Supabase
- store allowed categories in project settings and expose in agent context
- filter global knowledge retrieval by selected categories
- provide workspace settings page to choose categories
- route settings page and update supabase RPC typings

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68423bd944b48321b4c77f91f25ca22f