### PR TITLE
Expand marketing task detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "bun test"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/src/utils/chatTaskDetection.ts
+++ b/src/utils/chatTaskDetection.ts
@@ -46,10 +46,17 @@ export function detectTaskType(message: string): AgentTaskType {
     lowerMessage.includes('marketing') ||
     lowerMessage.includes('campaign') ||
     lowerMessage.includes('advertisement') ||
+    lowerMessage.includes('advertising') ||
     lowerMessage.includes('promotion') ||
     lowerMessage.includes('brand') ||
     lowerMessage.includes('target audience') ||
-    lowerMessage.includes('social media post')
+    lowerMessage.includes('social media post') ||
+    lowerMessage.includes('lead generation') ||
+    lowerMessage.includes('sales funnel') ||
+    lowerMessage.includes('seo') ||
+    lowerMessage.includes('search engine optimization') ||
+    lowerMessage.includes('conversion') ||
+    lowerMessage.includes('growth')
   ) {
     return 'marketing';
   }

--- a/tests/chatTaskDetection.test.ts
+++ b/tests/chatTaskDetection.test.ts
@@ -1,0 +1,20 @@
+import { test, expect } from "bun:test";
+import { detectTaskType } from "../src/utils/chatTaskDetection";
+
+test("lead generation maps to marketing", () => {
+  expect(detectTaskType("Need help with lead generation for our business")).toBe(
+    "marketing"
+  );
+});
+
+test("sales funnel phrase maps to marketing", () => {
+  expect(detectTaskType("Create a sales funnel to boost conversions")).toBe(
+    "marketing"
+  );
+});
+
+test("SEO and conversion growth phrase maps to marketing", () => {
+  expect(
+    detectTaskType("How do we improve SEO to increase conversion and growth?")
+  ).toBe("marketing");
+});


### PR DESCRIPTION
## Summary
- broaden marketing phrase detection for Chat Task Detection utility
- add bun-based unit tests for new marketing phrases
- include `test` script in package.json

## Testing
- `bun test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684251bd8a548321b20b3206c4e53ebe