### PR TITLE
Add force multi-agent mode

### DIFF
--- a/src/components/chat/ChatInterface.tsx
+++ b/src/components/chat/ChatInterface.tsx
@@ -53,6 +53,8 @@ export function ChatInterface({
     setQualityThreshold,
     maxIterations,
     setMaxIterations,
+    forceMultiAgent,
+    setForceMultiAgent,
     useMultiAgent,
     setUseMultiAgent,
     thinkActive,
@@ -200,11 +202,25 @@ export function ChatInterface({
                       checked={useMultiAgent} 
                       onCheckedChange={setUseMultiAgent} 
                     />
-                  </div>
-                  <p className="text-xs text-white/60">
-                    {useMultiAgent ? "Using specialized agents for better marketing advice (RAG + Marketing Expert + Quality Control)" : "Using single AI agent system"}
-                  </p>
                 </div>
+                <p className="text-xs text-white/60">
+                  {useMultiAgent ? "Using specialized agents for better marketing advice (RAG + Marketing Expert + Quality Control)" : "Using single AI agent system"}
+                </p>
+              </div>
+
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <Label htmlFor="force-multi-agent" className="text-sm">Force Multi-Agent</Label>
+                  <Switch
+                    id="force-multi-agent"
+                    checked={forceMultiAgent}
+                    onCheckedChange={setForceMultiAgent}
+                  />
+                </div>
+                <p className="text-xs text-white/60">
+                  When enabled, the multi-agent system will handle all tasks regardless of type
+                </p>
+              </div>
                 
                 <div className="space-y-2">
                   <div className="flex items-center justify-between">

--- a/src/hooks/use-chat-messaging.ts
+++ b/src/hooks/use-chat-messaging.ts
@@ -43,7 +43,8 @@ export function useChatMessaging({
   const [minQualityScore, setMinQualityScore] = useState(60);
   const [evaluation, setEvaluation] = useState<ChatEvaluation | undefined>(undefined);
   const [thinkActive, setThinkActive] = useState(false);
-  const [useMultiAgent, setUseMultiAgent] = useState(true); // New state for multi-agent toggle
+  const [useMultiAgent, setUseMultiAgent] = useState(true); // Toggle multi-agent usage for marketing tasks
+  const [forceMultiAgent, setForceMultiAgent] = useState(false); // Force multi-agent mode for all tasks
   const { toast } = useToast();
   
   // Send message function with multi-agent integration
@@ -85,8 +86,11 @@ export function useChatMessaging({
         
         let response;
         
-        // Use multi-agent system for marketing-related queries
-        if (useMultiAgent && (detectedTaskType === 'marketing' || detectedTaskType === 'email' || detectedTaskType === 'content')) {
+        // Use multi-agent system for supported task types or when forced
+        if (
+          useMultiAgent &&
+          (forceMultiAgent || ['marketing', 'email', 'content', 'summary', 'research'].includes(detectedTaskType))
+        ) {
           console.log('Using multi-agent system for enhanced marketing response');
           
           // Import and use multi-agent service
@@ -230,7 +234,7 @@ export function useChatMessaging({
         setIsLoading(false);
       }
     },
-    [projectId, threadId, conversationId, addMessage, onConversationCreated, toast, setLastSources, saveMessageToDatabase, useMemory, usePromptChain, qualityThreshold, maxIterations, minQualityScore, thinkActive, useMultiAgent]
+    [projectId, threadId, conversationId, addMessage, onConversationCreated, toast, setLastSources, saveMessageToDatabase, useMemory, usePromptChain, qualityThreshold, maxIterations, minQualityScore, thinkActive, useMultiAgent, forceMultiAgent]
   );
 
   return {
@@ -251,6 +255,8 @@ export function useChatMessaging({
     evaluation,
     thinkActive,
     setThinkActive,
+    forceMultiAgent,
+    setForceMultiAgent,
     useMultiAgent, // Export the new state
     setUseMultiAgent, // Export the setter
     handleSendMessage


### PR DESCRIPTION
## Summary
- extend multi-agent check to include summary and research tasks
- add a `forceMultiAgent` toggle to always use the multi-agent system
- expose the new setting in the chat interface

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684251c4899c8321b71317ec3f183960