### PR TITLE
Pass threshold to evaluation function

### DIFF
--- a/supabase/functions/agent-chat/index.ts
+++ b/supabase/functions/agent-chat/index.ts
@@ -374,7 +374,8 @@ Current expertise focus: ${taskType === 'research' ? 'Deep analysis and fact-fin
             query: message,
             response: currentResponse,
             context: context,
-            taskType: taskType
+            taskType: taskType,
+            qualityThreshold: qualityThreshold
           }
         });
 

--- a/supabase/functions/evaluate-response/index.ts
+++ b/supabase/functions/evaluate-response/index.ts
@@ -17,11 +17,12 @@ serve(async (req) => {
   }
 
   try {
-    const { 
-      response, 
-      originalQuery, 
+    const {
+      response,
+      originalQuery,
       taskType = 'general',
-      context = []
+      context = [],
+      qualityThreshold = 90
     } = await req.json();
 
     if (!response || !originalQuery) {
@@ -117,7 +118,7 @@ serve(async (req) => {
     return new Response(JSON.stringify({
       score,
       feedback: evaluationFeedback,
-      passesThreshold: score >= 90 // 90% is our target threshold
+      passesThreshold: score >= qualityThreshold
     }), {
       headers: { ...corsHeaders, 'Content-Type': 'application/json' }
     });


### PR DESCRIPTION
## Summary
- send `qualityThreshold` when calling the evaluation function
- respect provided threshold in `evaluate-response` function

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684251d0108c832196e78e52dedb1f7f