### PR TITLE
Add configurable quality threshold to evaluation

### DIFF
--- a/supabase/functions/agent-chat/index.ts
+++ b/supabase/functions/agent-chat/index.ts
@@ -374,7 +374,8 @@ Current expertise focus: ${taskType === 'research' ? 'Deep analysis and fact-fin
             query: message,
             response: currentResponse,
             context: context,
-            taskType: taskType
+            taskType: taskType,
+            qualityThreshold: qualityThreshold
           }
         });
 

--- a/supabase/functions/evaluate-response/index.ts
+++ b/supabase/functions/evaluate-response/index.ts
@@ -17,11 +17,12 @@ serve(async (req) => {
   }
 
   try {
-    const { 
-      response, 
-      originalQuery, 
+    const {
+      response,
+      originalQuery,
       taskType = 'general',
-      context = []
+      context = [],
+      qualityThreshold = 90
     } = await req.json();
 
     if (!response || !originalQuery) {
@@ -117,7 +118,7 @@ serve(async (req) => {
     return new Response(JSON.stringify({
       score,
       feedback: evaluationFeedback,
-      passesThreshold: score >= 90 // 90% is our target threshold
+      passesThreshold: score >= qualityThreshold
     }), {
       headers: { ...corsHeaders, 'Content-Type': 'application/json' }
     });


### PR DESCRIPTION
## Summary
- include `qualityThreshold` when invoking `evaluate-response`
- allow `evaluate-response` to take `qualityThreshold` and use it when determining pass/fail

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68425304a118832197ed717ef8d381fc