### PR TITLE
Extend marketing keyword detection

### DIFF
--- a/src/utils/chatTaskDetection.ts
+++ b/src/utils/chatTaskDetection.ts
@@ -49,7 +49,13 @@ export function detectTaskType(message: string): AgentTaskType {
     lowerMessage.includes('promotion') ||
     lowerMessage.includes('brand') ||
     lowerMessage.includes('target audience') ||
-    lowerMessage.includes('social media post')
+    lowerMessage.includes('social media post') ||
+    lowerMessage.includes('lead generation') ||
+    lowerMessage.includes('sales funnel') ||
+    lowerMessage.includes('advertising strategy') ||
+    lowerMessage.includes('seo') ||
+    lowerMessage.includes('conversion') ||
+    lowerMessage.includes('growth')
   ) {
     return 'marketing';
   }

--- a/tests/chatTaskDetection.test.ts
+++ b/tests/chatTaskDetection.test.ts
@@ -1,0 +1,31 @@
+import { test, expect } from "bun:test";
+import { detectTaskType } from "../src/utils/chatTaskDetection.ts";
+
+test("lead generation query detected as marketing", () => {
+  expect(detectTaskType("We need a lead generation strategy")).toBe("marketing");
+});
+
+test("sales funnel query detected as marketing", () => {
+  expect(detectTaskType("How do I build a sales funnel for my SaaS product?"))
+    .toBe("marketing");
+});
+
+test("advertising strategy query detected as marketing", () => {
+  expect(detectTaskType("I need help with an advertising strategy for my new app."))
+    .toBe("marketing");
+});
+
+test("SEO query detected as marketing", () => {
+  expect(detectTaskType("Tips for SEO to increase traffic."))
+    .toBe("marketing");
+});
+
+test("conversion query detected as marketing", () => {
+  expect(detectTaskType("Improve conversion on landing page"))
+    .toBe("marketing");
+});
+
+test("growth query detected as marketing", () => {
+  expect(detectTaskType("Strategies for growth marketing"))
+    .toBe("marketing");
+});


### PR DESCRIPTION
## Summary
- expand marketing keyword list in `detectTaskType`
- add unit tests using bun to cover new phrases

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_6842530976dc8321a1323cb80a400a4e